### PR TITLE
[SA-50840] Use ephemeral browser for SSO authentication

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -116,6 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
           authenticationVC.presentationContextProvider = self;
+          authenticationVC.prefersEphemeralWebBrowserSession = YES;
       }
 #endif
       _webAuthenticationVC = authenticationVC;


### PR DESCRIPTION
Use a private browser session for SSO authentication to avoid sharing the authentication state with the external Safari browser. This will also avoid presenting the “annoying” popup before login.

Issue on AppAuth: https://github.com/openid/AppAuth-iOS/issues/402