### PR TITLE
[SA-54376] Fix OIDAuthState decoding

### DIFF
--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -185,8 +185,8 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
   }
 
-  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClass:[OIDServiceDiscovery class]
-                                                                  forKey:kDiscoveryDocumentKey];
+  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[OIDServiceDiscovery class], [NSDictionary class], [NSArray class], nil]
+                                                                    forKey:kDiscoveryDocumentKey];
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint


### PR DESCRIPTION
Since iOS 12, `NSKeyedUnarchiver.unarchiveObject(with:)` method got deprecated and the suggested way to unarchive a previously archived object is with `NSKeyedUnarchiver.unarchivedObject(ofClass:from:)`. Unfortunately there is a bug in AppAuth implementation that results in an assertion and the unarchive failes with the following error `*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'The response_type "(null)" isn't supported. AppAuth only supports the "code" or "code id_token" response_type.'`

We can not use our workaround since now with migrating to Xcode 13, the deprecation throws a warning and it would fail our CI pipeline if we were to continue using the deprecated method.

See the issue in AppAuth's GitHub page: https://github.com/openid/AppAuth-iOS/issues/479
See the issue in our implementation: https://github.com/sumup/identity-ios/blob/master/SMPIdentity/AppAuth/AuthStateStorage.swift#L36-L54