### PR TITLE
[SA-55649] Fix crash on SFSafariVC fallback

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -113,12 +113,10 @@ NS_ASSUME_NONNULL_BEGIN
           [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
         }
       }];
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-      if (@available(iOS 13.0, *)) {
-          authenticationVC.presentationContextProvider = self;
-          authenticationVC.prefersEphemeralWebBrowserSession = YES;
-      }
-#endif
+
+      authenticationVC.presentationContextProvider = self;
+      authenticationVC.prefersEphemeralWebBrowserSession = YES;
+
       _webAuthenticationVC = authenticationVC;
       openedUserAgent = [authenticationVC start];
     }

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -125,19 +125,18 @@ NS_ASSUME_NONNULL_BEGIN
       authenticationVC.prefersEphemeralWebBrowserSession = YES;
 
       if (@available(iOS 13.4, *)) {
-        BOOL canStart = [authenticationVC canStart];
-        if (canStart) {
+        if ([authenticationVC canStart]) {
           openedUserAgent = [authenticationVC start];
         }
       } else {
         // `canStart` is only available in iOS 13.4
         // we need to work around the fallback logic to not trigger the result block twice
         openedUserAgent = [authenticationVC start];
-        didFinishSetup = YES;
       }
 
       if (openedUserAgent) {
         _webAuthenticationVC = authenticationVC;
+        didFinishSetup = YES;
       }
     }
   }


### PR DESCRIPTION
Problem:
`ASWebAuthenticationSession.start()` can return `false` meaning that it failed to start, but that automatically calls the `completionHandler` even before returning, which will invalidate the session automatically. In this case, the code falls back to `SFSafariViewController` which even on a successful login will fail and crash the application because the SDK will try to process an authorization response when the session has already been invalidated.

Resolution:
Make sure to only process completionHandler from `ASWebAuthenticationSession` when the auth presentation was successful.