### PR TITLE
Allow customizing the ID Token validator

### DIFF
--- a/Source/AppAuthCore/OIDAuthorizationService.h
+++ b/Source/AppAuthCore/OIDAuthorizationService.h
@@ -23,6 +23,7 @@
 @class OIDAuthorizationResponse;
 @class OIDEndSessionRequest;
 @class OIDEndSessionResponse;
+@class OIDIDTokenValidator;
 @class OIDRegistrationRequest;
 @class OIDRegistrationResponse;
 @class OIDServiceConfiguration;
@@ -89,6 +90,10 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
         Configurations may be created manually, or via an OpenID Connect Discovery Document.
  */
 @property(nonatomic, readonly) OIDServiceConfiguration *configuration;
+
+/*! @brief The ID Token's validator instance used in the `performTokenRequest` methods. If the property is not set, the default validator will be used.
+ */
+@property(nonatomic, class) OIDIDTokenValidator *idTokenValidator;
 
 /*! @internal
     @brief Unavailable. This class should not be initialized.

--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -311,6 +311,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDAuthorizationService
 
+static OIDIDTokenValidator *_idTokenValidator;
+
++ (OIDIDTokenValidator *)idTokenValidator {
+  if (!_idTokenValidator) {
+    _idTokenValidator = [OIDIDTokenValidator new];
+  }
+  return _idTokenValidator;
+}
+
++ (void)setIdTokenValidator:(OIDIDTokenValidator *)idTokenValidator {
+  _idTokenValidator = idTokenValidator;
+}
+
 + (void)discoverServiceConfigurationForIssuer:(NSURL *)issuerURL
                                    completion:(OIDDiscoveryCallback)completion {
   NSURL *fullDiscoveryURL =
@@ -533,8 +546,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     // If an ID Token is included in the response, validates the ID Token.
     if (tokenResponse.idToken) {
-      NSError *idTokenValidationError = [[OIDIDTokenValidator new] validateIDTokenFromTokenResponse:tokenResponse
-                                                                              authorizationResponse:authorizationResponse];
+      OIDIDTokenValidator *idTokenValidator = self.idTokenValidator;
+      NSError *idTokenValidationError = [idTokenValidator validateIDTokenFromTokenResponse:tokenResponse
+                                                                     authorizationResponse:authorizationResponse];
       if (idTokenValidationError) {
         dispatch_async(dispatch_get_main_queue(), ^{
           callback(nil, idTokenValidationError);


### PR DESCRIPTION
These changes allow users of the SDK to override the ID Token Validator with a custom implementation without introducing breaking changes into the API.