### PR TITLE
Separate id token validator into a separate class

### DIFF
--- a/Source/AppAuth.h
+++ b/Source/AppAuth.h
@@ -29,6 +29,7 @@
 #import "OIDExternalUserAgentSession.h"
 #import "OIDGrantTypes.h"
 #import "OIDIDToken.h"
+#import "OIDIDTokenValidator.h"
 #import "OIDRegistrationRequest.h"
 #import "OIDRegistrationResponse.h"
 #import "OIDResponseTypes.h"

--- a/Source/AppAuthCore.h
+++ b/Source/AppAuthCore.h
@@ -29,6 +29,7 @@
 #import "OIDExternalUserAgentSession.h"
 #import "OIDGrantTypes.h"
 #import "OIDIDToken.h"
+#import "OIDIDTokenValidator.h"
 #import "OIDRegistrationRequest.h"
 #import "OIDRegistrationResponse.h"
 #import "OIDResponseTypes.h"

--- a/Source/AppAuthCore/OIDIDTokenValidator.h
+++ b/Source/AppAuthCore/OIDIDTokenValidator.h
@@ -1,0 +1,36 @@
+//
+//  OIDIDTokenVerificator.h
+//  
+//
+//  Created by Andras Kadar on 4/11/22.
+//
+
+#import <Foundation/Foundation.h>
+
+@class OIDAuthorizationResponse;
+@class OIDIDToken;
+@class OIDTokenResponse;
+
+@interface OIDIDTokenValidator : NSObject
+
+/// Convenience accessor to the validation. For details please refer to the `validateIDToken:issuer:clientID:grantType:nonce:` method.
+- (NSError *)validateIDTokenFromTokenResponse:(OIDTokenResponse *)tokenResponse
+                        authorizationResponse:(OIDAuthorizationResponse *)authorizationResponse;
+
+/// If an ID Token is available, validates the ID Token following the rules
+/// in OpenID Connect Core Section 3.1.3.7 for features that AppAuth directly supports
+/// (which excludes rules #1, #4, #5, #7, #8, #12, and #13). Regarding rule #6, ID Tokens
+/// received by this class are received via direct communication between the Client and the Token
+/// Endpoint, thus we are exercising the option to rely only on the TLS validation. AppAuth
+/// has a zero dependencies policy, and verifying the JWT signature would add a dependency.
+/// Users of the library are welcome to perform the JWT signature verification themselves should
+/// they wish.
+///
+/// \return `nil` if the token is valid, a validation error with details if the validation failed
+- (NSError *)validateIDToken:(OIDIDToken *)idToken
+                      issuer:(NSURL *)issuer
+                    clientID:(NSString *)clientID
+                   grantType:(NSString *)grantType
+                       nonce:(NSString *)nonce;
+
+@end

--- a/Source/AppAuthCore/OIDIDTokenValidator.m
+++ b/Source/AppAuthCore/OIDIDTokenValidator.m
@@ -1,0 +1,119 @@
+//
+//  OIDIDTokenVerificator.m
+//  
+//
+//  Created by Andras Kadar on 4/11/22.
+//
+
+#import "OIDIDTokenValidator.h"
+
+#import "OIDAuthorizationRequest.h"
+#import "OIDAuthorizationResponse.h"
+#import "OIDErrorUtilities.h"
+#import "OIDIDToken.h"
+#import "OIDServiceConfiguration.h"
+#import "OIDTokenRequest.h"
+#import "OIDTokenResponse.h"
+
+/*! @brief Max allowable iat (Issued At) time skew
+ @see https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+ */
+static int const kOIDAuthorizationSessionIATMaxSkew = 600;
+
+@implementation OIDIDTokenValidator
+
+- (NSError *)validateIDTokenFromTokenResponse:(OIDTokenResponse *)tokenResponse
+                        authorizationResponse:(OIDAuthorizationResponse *)authorizationResponse {
+    return [self validateIDToken:[[OIDIDToken alloc] initWithIDTokenString:tokenResponse.idToken]
+                          issuer:tokenResponse.request.configuration.issuer
+                        clientID:tokenResponse.request.clientID
+                       grantType:tokenResponse.request.grantType
+                           nonce:authorizationResponse.request.nonce];
+}
+
+- (NSError *)validateIDToken:(OIDIDToken *)idToken
+                      issuer:(NSURL *)issuer
+                    clientID:(NSString *)clientID
+                   grantType:(NSString *)grantType
+                       nonce:(NSString *)nonce {
+    if (!idToken) {
+        return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenParsingError
+                                underlyingError:nil
+                                    description:@"ID Token parsing failed"];
+    }
+
+    // OpenID Connect Core Section 3.1.3.7. rule #1
+    // Not supported: AppAuth does not support JWT encryption.
+
+    // OpenID Connect Core Section 3.1.3.7. rule #2
+    // Validates that the issuer in the ID Token matches that of the discovery document.
+    if (issuer && ![idToken.issuer isEqual:issuer]) {
+        return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
+                                underlyingError:nil
+                                    description:@"Issuer mismatch"];
+    }
+
+    // OpenID Connect Core Section 3.1.3.7. rule #3 & Section 2 azp Claim
+    // Validates that the aud (audience) Claim contains the client ID, or that the azp
+    // (authorized party) Claim matches the client ID.
+    if (![idToken.audience containsObject:clientID] &&
+        ![idToken.claims[@"azp"] isEqualToString:clientID]) {
+        return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
+                                underlyingError:nil
+                                    description:@"Audience mismatch"];
+    }
+
+    // OpenID Connect Core Section 3.1.3.7. rules #4 & #5
+    // Not supported.
+
+    // OpenID Connect Core Section 3.1.3.7. rule #6
+    // As noted above, AppAuth only supports the code flow which results in direct communication
+    // of the ID Token from the Token Endpoint to the Client, and we are exercising the option to
+    // use TSL server validation instead of checking the token signature. Users may additionally
+    // check the token signature should they wish.
+
+    // OpenID Connect Core Section 3.1.3.7. rules #7 & #8
+    // Not applicable. See rule #6.
+
+    // OpenID Connect Core Section 3.1.3.7. rule #9
+    // Validates that the current time is before the expiry time.
+    NSTimeInterval expiresAtDifference = [idToken.expiresAt timeIntervalSinceNow];
+    if (expiresAtDifference < 0) {
+        return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
+                                underlyingError:nil
+                                    description:@"ID Token expired"];
+    }
+
+    // OpenID Connect Core Section 3.1.3.7. rule #10
+    // Validates that the issued at time is not more than +/- 10 minutes on the current time.
+    NSTimeInterval issuedAtDifference = [idToken.issuedAt timeIntervalSinceNow];
+    if (fabs(issuedAtDifference) > kOIDAuthorizationSessionIATMaxSkew) {
+        NSString *message =
+        [NSString stringWithFormat:@"Issued at time is more than %d seconds before or after "
+         "the current time",
+         kOIDAuthorizationSessionIATMaxSkew];
+        return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
+                                underlyingError:nil
+                                    description:message];
+    }
+
+    // Only relevant for the authorization_code response type
+    if ([grantType isEqual:OIDGrantTypeAuthorizationCode]) {
+        // OpenID Connect Core Section 3.1.3.7. rule #11
+        // Validates the nonce.
+        if (nonce && ![idToken.nonce isEqual:nonce]) {
+            return [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
+                                    underlyingError:nil
+                                        description:@"Nonce mismatch"];
+        }
+    }
+
+    // OpenID Connect Core Section 3.1.3.7. rules #12
+    // ACR is not directly supported by AppAuth.
+
+    // OpenID Connect Core Section 3.1.3.7. rules #12
+    // max_age is not directly supported by AppAuth.
+    return nil;
+}
+
+@end

--- a/Source/CoreFramework/AppAuthCore.h
+++ b/Source/CoreFramework/AppAuthCore.h
@@ -37,6 +37,7 @@ FOUNDATION_EXPORT const unsigned char AppAuthCoreVersionString[];
 #import <AppAuthCore/OIDExternalUserAgentSession.h>
 #import <AppAuthCore/OIDGrantTypes.h>
 #import <AppAuthCore/OIDIDToken.h>
+#import <AppAuthCore/OIDIDTokenValidator.h>
 #import <AppAuthCore/OIDRegistrationRequest.h>
 #import <AppAuthCore/OIDRegistrationResponse.h>
 #import <AppAuthCore/OIDResponseTypes.h>

--- a/Source/Framework/AppAuth.h
+++ b/Source/Framework/AppAuth.h
@@ -37,6 +37,7 @@ FOUNDATION_EXPORT const unsigned char AppAuthVersionString[];
 #import <AppAuth/OIDExternalUserAgentSession.h>
 #import <AppAuth/OIDGrantTypes.h>
 #import <AppAuth/OIDIDToken.h>
+#import <AppAuth/OIDIDTokenValidator.h>
 #import <AppAuth/OIDRegistrationRequest.h>
 #import <AppAuth/OIDRegistrationResponse.h>
 #import <AppAuth/OIDResponseTypes.h>


### PR DESCRIPTION
Separate the concerns of validation and authorization service by extracting the id token validator. This way the id token validation can be used and tested independent of the `performTokenRequest` method's implementation.